### PR TITLE
Color feature backed by an int map.

### DIFF
--- a/src/main/java/org/mastodon/features/ColorFeature.java
+++ b/src/main/java/org/mastodon/features/ColorFeature.java
@@ -1,0 +1,64 @@
+package org.mastodon.features;
+
+import java.awt.Color;
+
+import org.mastodon.collection.RefCollection;
+import org.mastodon.collection.RefCollections;
+import org.mastodon.features.FeatureRegistry.DuplicateKeyException;
+
+import gnu.trove.map.TObjectIntMap;
+
+/**
+ * Color feature backed by an {@code int} map. The map stores the RGBA code.
+ * This feature then returns the corresponding {@link Color} object.
+ * <p>
+ * We use the {@code rgba = 0} code for {@code noEntryValue} in the map, which
+ * corresponds to the completely transparent black color. So this feature cannot
+ * store this color.
+ * 
+ * @author Jean-Yves Tinevez
+ *
+ * @param <O>
+ *            type of object to which feature should be attached.
+ */
+public class ColorFeature< O > extends Feature< TObjectIntMap< O >, O, FeatureValue< Color > >
+{
+
+	public ColorFeature( final String name ) throws DuplicateKeyException
+	{
+		super( name );
+	}
+
+	@Override
+	protected TObjectIntMap< O > createFeatureMap( final RefCollection< O > pool )
+	{
+		return RefCollections.createRefIntMap( pool, 0 );
+	}
+
+	@Override
+	protected FeatureCleanup< O > createFeatureCleanup( final TObjectIntMap< O > featureMap )
+	{
+		return new FeatureCleanup< O >()
+		{
+			@Override
+			public void delete( final O object )
+			{
+				featureMap.remove( object );
+			}
+		};
+	}
+
+	@Override
+	public UndoFeatureMap< O > createUndoFeatureMap( final TObjectIntMap< O > featureMap )
+	{
+		return new IntUndoFeatureMap<>( featureMap, 0 );
+	}
+
+	@Override
+	public ColorFeatureValue< O > createFeatureValue( final O object, final Features< O > features )
+	{
+		return new ColorFeatureValue< O >( features.getFeatureMap( this ),
+				object,
+				new NotifyValueChange<>( features, this, object ) );
+	}
+}

--- a/src/main/java/org/mastodon/features/ColorFeatureValue.java
+++ b/src/main/java/org/mastodon/features/ColorFeatureValue.java
@@ -1,0 +1,99 @@
+package org.mastodon.features;
+
+import java.awt.Color;
+
+import org.mastodon.util.ColorStore;
+
+import gnu.trove.map.TObjectIntMap;
+
+
+/**
+ * Feature value for colors, based on storing their <code>int</code> RGBA code
+ * in a map.
+ *
+ * @param <O>
+ *            type of object to which the feature should be attached.
+ *
+ * @author Jean-Yves Tinevez
+ */
+public class ColorFeatureValue< O > implements FeatureValue< Color >
+{
+	private final TObjectIntMap< O > featureMap;
+
+	private final O object;
+
+	private final NotifyFeatureValueChange notify;
+
+	protected ColorFeatureValue( final TObjectIntMap< O > featureMap, final O object, final NotifyFeatureValueChange notify )
+	{
+		this.featureMap = featureMap;
+		this.object = object;
+		this.notify = notify;
+	}
+
+	@Override
+	public void set( final Color value )
+	{
+		notify.notifyBeforeFeatureChange();
+		if ( value == null )
+			featureMap.remove( object );
+		else
+			featureMap.put( object, value.getRGB() );
+	}
+
+	/**
+	 * Sets the color of this item via the color's RGBA. This {@code int} value
+	 * is such that {@code color = new Color(rgba, true)}.
+	 * <p>
+	 * This value consists of the alpha component in bits 24-31, the red
+	 * component in bits 16-23, the green component in bits 8-15, and the blue
+	 * component in bits 0-7.
+	 * 
+	 * @param value
+	 *            the RGBA {@code int} value.
+	 */
+	public void set( final int value )
+	{
+		notify.notifyBeforeFeatureChange();
+		featureMap.put( object, value );
+	}
+
+	@Override
+	public void remove()
+	{
+		notify.notifyBeforeFeatureChange();
+		featureMap.remove( object );
+	}
+
+	@Override
+	public Color get()
+	{
+		final int rgba = featureMap.get( object );
+		if ( rgba == featureMap.getNoEntryValue() )
+			return null;
+
+		return ColorStore.get( rgba );
+	}
+
+	/**
+	 * Returns the RGBA code for the color feature of this item. This
+	 * {@code int} value is such that {@code color = new Color(rgba, true)}.
+	 * <p>
+	 * This value consists of the alpha component in bits 24-31, the red
+	 * component in bits 16-23, the green component in bits 8-15, and the blue
+	 * component in bits 0-7.
+	 * 
+	 * @return the RGBA {@code int} value.
+	 */
+	public int getRGBA()
+	{
+		return featureMap.get( object );
+	}
+
+	@Override
+	public boolean isSet()
+	{
+		return featureMap.containsKey( object );
+	}
+
+}

--- a/src/main/java/org/mastodon/util/ColorStore.java
+++ b/src/main/java/org/mastodon/util/ColorStore.java
@@ -1,0 +1,46 @@
+package org.mastodon.util;
+
+import java.awt.Color;
+
+import gnu.trove.map.TIntObjectMap;
+import gnu.trove.map.hash.TIntObjectHashMap;
+
+/**
+ * A static color store.
+ * <p>
+ * Color objects are immutable but need creation every time a color is required.
+ * This static utility aims at avoiding recreating color objects by storing
+ * existing colors in a map. When queried for a color, if it exists in the map,
+ * the instance is returned. If not, it is created and stored in the map for
+ * later use.
+ * 
+ * @author Jean-Yves Tinevez
+ *
+ */
+public class ColorStore
+{
+	private static final TIntObjectMap< Color > colors = new TIntObjectHashMap<>();
+
+	/**
+	 * Returns a sRGB color with the specified combined RGBA value consisting of
+	 * the alpha component in bits 24-31, the red component in bits 16-23, the
+	 * green component in bits 8-15, and the blue component in bits 0-7.
+	 * 
+	 * @param rgba
+	 *            the RGBA code.
+	 * @return a color.
+	 */
+	public static final Color get( final int rgba )
+	{
+		Color color = colors.get( rgba );
+		if ( null == color )
+		{
+			color = new Color( rgba, true);
+			colors.put( rgba, color);
+		}
+		return color;
+	}
+
+	private ColorStore()
+	{}
+}

--- a/src/test/java/org/mastodon/features/ColorFeatureBenchmark.java
+++ b/src/test/java/org/mastodon/features/ColorFeatureBenchmark.java
@@ -1,0 +1,164 @@
+package org.mastodon.features;
+
+import java.awt.Color;
+import java.util.Random;
+
+import org.mastodon.collection.ref.RefArrayList;
+import org.mastodon.pooldemo.Vector3;
+import org.mastodon.pooldemo.Vector3Pool;
+
+public class ColorFeatureBenchmark
+{
+	// 5 millions.
+	private static final int nobj = 5000000;
+
+	private static final int nrepeats = 5;
+
+	private static final Random ran = new Random( 1l );
+
+	public static void main( final String[] args )
+	{
+		/*
+		 * Use Object-based color feature.
+		 */
+
+		System.out.println();
+		final ObjFeature< Vector3, Color > colorFeature1 = new ObjFeature<>( "Color1" );
+		System.out.println( colorFeature1 );
+		testSetGetFeature( colorFeature1 );
+		testSparseColorsFeature( colorFeature1 );
+
+		/*
+		 * Direct color features.
+		 */
+
+		System.out.println();
+		final ColorFeature< Vector3 > colorFeature2 = new ColorFeature<>( "Color2" );
+		System.out.println( colorFeature2 );
+		testSetGetFeature( colorFeature2 );
+		testSparseColorsFeature( colorFeature2 );
+
+		/*
+		 * Do it again.
+		 */
+
+		/*
+		 * Use Object-based color feature.
+		 */
+
+		System.out.println();
+		System.out.println( colorFeature1 );
+		testSetGetFeature( colorFeature1 );
+		testSparseColorsFeature( colorFeature1 );
+
+		/*
+		 * Direct color features.
+		 */
+
+		System.out.println();
+		System.out.println( colorFeature2 );
+		testSetGetFeature( colorFeature2 );
+		testSparseColorsFeature( colorFeature2 );
+	}
+
+	private static final void testSetGetFeature( final Feature< ?, Vector3, FeatureValue< Color > > f )
+	{
+
+		// Create collection.
+		final Vector3Pool pool = new Vector3Pool( nobj );
+		final Vector3 ref = pool.createRef();
+		final RefArrayList< Vector3 > vecs = new RefArrayList<>( pool );
+		for ( int i = 0; i < nobj; i++ )
+			vecs.add( pool.create( ref ).init( i, i, i ) );
+
+		/*
+		 * Memory. This part requires the classmexer to be on build-path and
+		 * used as a java agent: -javaagent:classmexer.jar
+		 */
+//		final long size1 = com.javamex.classmexer.MemoryUtil.deepMemoryUsageOf( vecs.iterator().next().feature( f ) ) / 1000000;
+
+		// setting
+		final long s1 = System.currentTimeMillis();
+		for ( int i = 0; i < nrepeats; i++ )
+			for ( final Vector3 v : vecs )
+				v.feature( f ).set( new Color( ran.nextInt( 256 ^ 3 ) ) );
+
+		final long e1 = System.currentTimeMillis();
+		System.out.println( String.format( "Setting color feature for %d objects: %.1f ms.",
+				nobj, ( ( double ) e1 - s1 ) / nrepeats ) );
+
+		// getting
+		final long s2 = System.currentTimeMillis();
+		for ( int i = 0; i < nrepeats; i++ )
+		{
+			for ( final Vector3 v : vecs )
+			{
+				@SuppressWarnings( "unused" )
+				final Color color = v.feature( f ).get();
+			}
+		}
+		final long e2 = System.currentTimeMillis();
+		System.out.println( String.format( "Getting color feature for %d objects: %.1f ms.",
+				nobj, ( ( double ) e2 - s2 ) / nrepeats ) );
+
+		/*
+		 * Memory. This part requires the classmexer to be on build-path and
+		 * used as a java agent: -javaagent:classmexer.jar
+		 */
+//		final long size2 = com.javamex.classmexer.MemoryUtil.deepMemoryUsageOf( vecs.iterator().next().feature( f ) ) / 1000000;
+//		System.out.println( String.format( "Size of direct color feature storage for " + f + ": %d MB.", size2 - size1 ) );
+	}
+
+	private static final void testSparseColorsFeature( final Feature< ?, Vector3, FeatureValue< Color > > f )
+	{
+		// Number of different colors.
+		final int ncolors = 5;
+
+		// Create collection.
+		final Vector3Pool pool = new Vector3Pool( nobj );
+		final Vector3 ref = pool.createRef();
+		final RefArrayList< Vector3 > vecs = new RefArrayList<>( pool );
+		for ( int i = 0; i < nobj; i++ )
+			vecs.add( pool.create( ref ).init( i, i, i ) );
+
+		/*
+		 * Memory. This part requires the classmexer to be on build-path and
+		 * used as a java agent: -javaagent:classmexer.jar
+		 */
+//		final long size1 = com.javamex.classmexer.MemoryUtil.deepMemoryUsageOf( vecs.iterator().next().feature( f ) ) / 1000000;
+
+		// setting
+		final long s1 = System.currentTimeMillis();
+		for ( int i = 0; i < nrepeats; i++ )
+			for ( final Vector3 v : vecs )
+				v.feature( f ).set( new Color( 100 + i % ncolors ) );
+
+		final long e1 = System.currentTimeMillis();
+		System.out.println( String.format( "Setting sparse color feature for %d objects: %.1f ms.",
+				nobj, ( ( double ) e1 - s1 ) / nrepeats ) );
+
+		// getting
+		final long s2 = System.currentTimeMillis();
+		for ( int i = 0; i < nrepeats; i++ )
+		{
+			for ( final Vector3 v : vecs )
+			{
+				@SuppressWarnings( "unused" )
+				final Color color = v.feature( f ).get();
+			}
+		}
+		final long e2 = System.currentTimeMillis();
+		System.out.println( String.format( "Getting sparse color feature for %d objects: %.1f ms.",
+				nobj, ( ( double ) e2 - s2 ) / nrepeats ) );
+
+		/*
+		 * Memory. This part requires the classmexer to be on build-path and
+		 * used as a java agent: -javaagent:classmexer.jar
+		 */
+//		final long size2 = com.javamex.classmexer.MemoryUtil.deepMemoryUsageOf( vecs.iterator().next().feature( f ) ) / 1000000;
+//		System.out.println( String.format( "Size of direct color feature storage for " + f + ": %d MB.", size2 - size1 ) );
+	}
+
+	private ColorFeatureBenchmark()
+	{}
+}


### PR DESCRIPTION
The map stores the RGBA code. This feature then returns the corresponding Color object.We use the rgba = 0 code for noEntryValue in the map, which corresponds to the completely transparent black color. So this feature cannot store this color.

This feature offers a more efficient storage at the expense of access time:

org.mastodon.features.ObjFeature("Color1")
- random colors
Setting color feature for 5000000 objects: 211.6 ms.
Getting color feature for 5000000 objects: 106.6 ms.
Size of direct color feature storage for org.mastodon.features.ObjFeature("Color1"): 212 MB.
- 5 different colors
Setting sparse color feature for 5000000 objects: 187.6 ms.
Getting sparse color feature for 5000000 objects: 110.4 ms.
Size of direct color feature storage for org.mastodon.features.ObjFeature("Color1"): 212 MB.

org.mastodon.features.ColorFeature("Color2")
- random colors
Setting color feature for 5000000 objects: 193.6 ms.
Getting color feature for 5000000 objects: 141.4 ms.
Size of direct color feature storage for org.mastodon.features.ColorFeature("Color2"): 52 MB.
- 5 different colors
Setting sparse color feature for 5000000 objects: 167.6 ms.
Getting sparse color feature for 5000000 objects: 141.8 ms.
Size of direct color feature storage for org.mastodon.features.ColorFeature("Color2"): 52 MB.
