### PR TITLE
Safe get object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ release.properties
 .settings/
 /samples/
 *.ucls
+.idea/
+*.iml

--- a/src/main/java/org/mastodon/RefPool.java
+++ b/src/main/java/org/mastodon/RefPool.java
@@ -58,6 +58,23 @@ public interface RefPool< O >
 	public O getObject( final int id, final O obj );
 
 	/**
+	 * Get the object associated with the given {@code id}.
+	 * <p>
+	 * If this pool stores {@link Ref} objects, the provided reference
+	 * {@code obj} will be used to refer to the object at {@code index} in the
+	 * pool, and returned.
+	 *
+	 * @param id
+	 *            internal pool index.
+	 * @param obj
+	 *            reusable reference that may be used to refer to object
+	 *            associated with {@code id}, and return it.
+	 * @return the object associated with the given {@code id} or {@code null}
+	 *         if no such object exists.
+	 */
+	public O getObjectIfExists( final int id, final O obj );
+
+	/**
 	 * Get the (unique) ID associated with the given object.
 	 * <p>
 	 * If the object is a {@link Ref}, then the ID depends on the data the

--- a/src/main/java/org/mastodon/collection/util/HashBimap.java
+++ b/src/main/java/org/mastodon/collection/util/HashBimap.java
@@ -1,5 +1,6 @@
 package org.mastodon.collection.util;
 
+import java.util.NoSuchElementException;
 import org.mastodon.RefPool;
 
 import gnu.trove.impl.Constants;
@@ -43,7 +44,13 @@ public class HashBimap< O > implements RefPool< O >
 	{
 		final O o = idToObj.get( id );
 		if ( o == null )
-			throw new IllegalArgumentException();
+			throw new NoSuchElementException();
+		return o;
+	}
+
+	@Override public O getObjectIfExists( final int id, final O obj )
+	{
+		final O o = idToObj.get( id );
 		return o;
 	}
 

--- a/src/main/java/org/mastodon/pool/Pool.java
+++ b/src/main/java/org/mastodon/pool/Pool.java
@@ -117,6 +117,21 @@ public abstract class Pool< O extends PoolObject< O, ?, T >, T extends MappedEle
 	}
 
 	@Override
+	public O getObjectIfExists( final int index, final O obj )
+	{
+		if ( index < 0 || index >= memPool.capacity )
+			return null;
+
+		obj.updateAccess( memPool, index );
+
+		final boolean isFree = obj.access.getInt( 0 ) == MemPool.FREE_ELEMENT_MAGIC_NUMBER;
+		if (isFree)
+			return null;
+
+		return obj;
+	}
+
+	@Override
 	public int getId( final O o )
 	{
 		return o.getInternalPoolIndex();

--- a/src/main/java/org/mastodon/undo/UndoIdBimap.java
+++ b/src/main/java/org/mastodon/undo/UndoIdBimap.java
@@ -85,6 +85,22 @@ public class UndoIdBimap< O > implements RefPool< O >
 		return objUndoIdBimap.getKey( undoId, ref );
 	}
 
+	/**
+	 * Returns the object mapped to the specified undo ID.
+	 *
+	 * @param undoId
+	 *            the undo ID.
+	 * @param ref
+	 *            a pool reference that might be used for object retrieval.
+	 * @return the object mapped to the specified undo ID, or <code>null</code>
+	 *         is there are no such undo ID stored in this map.
+	 */
+	@Override
+	public O getObjectIfExists( final int undoId, final O ref )
+	{
+		return objUndoIdBimap.getKey( undoId, ref );
+	}
+
 	@Override
 	public O createRef()
 	{


### PR DESCRIPTION
Add `RefPool.getIfExists(id,obj)` which returns `null` if no obj is associated to `id`. See https://github.com/fiji/TrackMate3/issues/34