### PR TITLE
Do not crash when removing/adding listeners from an empty listener collection.

### DIFF
--- a/src/main/java/org/mastodon/util/Listeners.java
+++ b/src/main/java/org/mastodon/util/Listeners.java
@@ -34,11 +34,15 @@ public interface Listeners< T >
 
 	default boolean addAll( final Collection< ? extends T > listeners )
 	{
+		if ( listeners.isEmpty() )
+			return false;
 		return listeners.stream().map( this::add ).reduce( Boolean::logicalOr ).get();
 	}
 
 	default boolean removeAll( final Collection< ? extends T > listeners )
 	{
+		if ( listeners.isEmpty() )
+			return false;
 		return listeners.stream().map( this::remove ).reduce( Boolean::logicalOr ).get();
 	}
 


### PR DESCRIPTION
Otherwise this error pops up:
```java
Exception in thread "AWT-EventQueue-0" java.util.NoSuchElementException: No value present
	at java.util.Optional.get(Optional.java:135)
	at org.mastodon.util.Listeners.removeAll(Listeners.java:42)
```