### PR TITLE
Checkbounds

### DIFF
--- a/src/main/java/org/mastodon/Options.java
+++ b/src/main/java/org/mastodon/Options.java
@@ -1,0 +1,18 @@
+package org.mastodon;
+
+public class Options
+{
+	/**
+	 * Whether the following checks should be made:
+	 * <ul>
+	 *     <li>Check whether {@code ByteUtils} methods access out of bounds array values, and throw ArrayIndexOutOfBoundsException.</li>
+	 *     <li>Check whether {@code Pool.getObject} tries to retrieve a freed element, and throw NoSuchElementException.</li>
+	 * </ul>
+	 */
+	public static final boolean DEBUG = false;
+
+//	static {
+//		String debug = System.getProperty( "mastodon-collection.debug", "false" ).trim();
+//		DEBUG = debug.isEmpty() || debug.equals( "true" );
+//	}
+}

--- a/src/main/java/org/mastodon/pool/ByteUtils.java
+++ b/src/main/java/org/mastodon/pool/ByteUtils.java
@@ -58,61 +58,85 @@ public class ByteUtils
 
 	public static void putInt( final int value, final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + INT_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		UNSAFE.putInt( array, BYTE_ARRAY_OFFSET + offset, value );
 	}
 
 	public static int getInt( final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + INT_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		return UNSAFE.getInt( array, BYTE_ARRAY_OFFSET + offset );
 	}
 
 	public static void putShort( final short value, final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + SHORT_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		UNSAFE.putShort( array, BYTE_ARRAY_OFFSET + offset, value );
 	}
 
 	public static short getShort( final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + SHORT_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		return UNSAFE.getShort( array, BYTE_ARRAY_OFFSET + offset );
 	}
 
 	public static void putLong( final long value, final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + LONG_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		UNSAFE.putLong( array, BYTE_ARRAY_OFFSET + offset, value );
 	}
 
 	public static long getLong( final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + LONG_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		return UNSAFE.getLong( array, BYTE_ARRAY_OFFSET + offset );
 	}
 
 	public static void putFloat( final float value, final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + FLOAT_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		UNSAFE.putFloat( array, BYTE_ARRAY_OFFSET + offset, value );
 	}
 
 	public static float getFloat( final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + FLOAT_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		return UNSAFE.getFloat( array, BYTE_ARRAY_OFFSET + offset );
 	}
 
 	public static void putDouble( final double value, final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + DOUBLE_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		UNSAFE.putDouble( array, BYTE_ARRAY_OFFSET + offset, value );
 	}
 
 	public static double getDouble( final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + DOUBLE_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		return UNSAFE.getDouble( array, BYTE_ARRAY_OFFSET + offset );
 	}
 
 	public static void putIndex( final int value, final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + INDEX_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		putInt( value, array, offset );
 	}
 
 	public static int getIndex( final byte[] array, final int offset )
 	{
+		if ( offset < 0 || array.length < offset + INDEX_SIZE )
+			throw new ArrayIndexOutOfBoundsException( offset );
 		return getInt( array, offset );
 	}
 

--- a/src/main/java/org/mastodon/pool/ByteUtils.java
+++ b/src/main/java/org/mastodon/pool/ByteUtils.java
@@ -3,7 +3,7 @@ package org.mastodon.pool;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
-
+import org.mastodon.Options;
 import sun.misc.Unsafe;
 
 /**
@@ -58,84 +58,84 @@ public class ByteUtils
 
 	public static void putInt( final int value, final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + INT_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + INT_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		UNSAFE.putInt( array, BYTE_ARRAY_OFFSET + offset, value );
 	}
 
 	public static int getInt( final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + INT_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + INT_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		return UNSAFE.getInt( array, BYTE_ARRAY_OFFSET + offset );
 	}
 
 	public static void putShort( final short value, final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + SHORT_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + SHORT_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		UNSAFE.putShort( array, BYTE_ARRAY_OFFSET + offset, value );
 	}
 
 	public static short getShort( final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + SHORT_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + SHORT_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		return UNSAFE.getShort( array, BYTE_ARRAY_OFFSET + offset );
 	}
 
 	public static void putLong( final long value, final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + LONG_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + LONG_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		UNSAFE.putLong( array, BYTE_ARRAY_OFFSET + offset, value );
 	}
 
 	public static long getLong( final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + LONG_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + LONG_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		return UNSAFE.getLong( array, BYTE_ARRAY_OFFSET + offset );
 	}
 
 	public static void putFloat( final float value, final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + FLOAT_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + FLOAT_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		UNSAFE.putFloat( array, BYTE_ARRAY_OFFSET + offset, value );
 	}
 
 	public static float getFloat( final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + FLOAT_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + FLOAT_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		return UNSAFE.getFloat( array, BYTE_ARRAY_OFFSET + offset );
 	}
 
 	public static void putDouble( final double value, final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + DOUBLE_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + DOUBLE_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		UNSAFE.putDouble( array, BYTE_ARRAY_OFFSET + offset, value );
 	}
 
 	public static double getDouble( final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + DOUBLE_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + DOUBLE_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		return UNSAFE.getDouble( array, BYTE_ARRAY_OFFSET + offset );
 	}
 
 	public static void putIndex( final int value, final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + INDEX_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + INDEX_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		putInt( value, array, offset );
 	}
 
 	public static int getIndex( final byte[] array, final int offset )
 	{
-		if ( offset < 0 || array.length < offset + INDEX_SIZE )
+		if ( Options.DEBUG && ( offset < 0 || array.length < offset + INDEX_SIZE ) )
 			throw new ArrayIndexOutOfBoundsException( offset );
 		return getInt( array, offset );
 	}

--- a/src/main/java/org/mastodon/pool/Pool.java
+++ b/src/main/java/org/mastodon/pool/Pool.java
@@ -104,13 +104,13 @@ public abstract class Pool< O extends PoolObject< O, ?, T >, T extends MappedEle
 	public O getObject( final int index, final O obj )
 	{
 		if ( index < 0 || index >= memPool.capacity )
-			throw new NoSuchElementException();
+			throw new NoSuchElementException( "index=" + index + " capacity=" + memPool.capacity + ", refClass=" + getRefClass().getSimpleName() );
 
 		obj.updateAccess( this, index );
 
 		final boolean isFree = obj.access.getInt( 0 ) == MemPool.FREE_ELEMENT_MAGIC_NUMBER;
 		if (isFree)
-			throw new NoSuchElementException();
+			throw new NoSuchElementException( "index=" + index + " is free, refClass=" + getRefClass().getSimpleName() );
 
 		return obj;
 	}

--- a/src/main/java/org/mastodon/pool/Pool.java
+++ b/src/main/java/org/mastodon/pool/Pool.java
@@ -4,6 +4,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.mastodon.Options;
 import org.mastodon.RefPool;
 import org.mastodon.pool.MemPool.PoolIterator;
 import org.mastodon.properties.HasPropertyMaps;
@@ -103,14 +104,17 @@ public abstract class Pool< O extends PoolObject< O, ?, T >, T extends MappedEle
 	@Override
 	public O getObject( final int index, final O obj )
 	{
-		if ( index < 0 || index >= memPool.capacity )
+		if ( Options.DEBUG && ( index < 0 || index >= memPool.capacity ) )
 			throw new NoSuchElementException( "index=" + index + " capacity=" + memPool.capacity + ", refClass=" + getRefClass().getSimpleName() );
 
 		obj.updateAccess( this, index );
 
-		final boolean isFree = obj.access.getInt( 0 ) == MemPool.FREE_ELEMENT_MAGIC_NUMBER;
-		if (isFree)
-			throw new NoSuchElementException( "index=" + index + " is free, refClass=" + getRefClass().getSimpleName() );
+		if ( Options.DEBUG )
+		{
+			final boolean isFree = obj.access.getInt( 0 ) == MemPool.FREE_ELEMENT_MAGIC_NUMBER;
+			if ( isFree )
+				throw new NoSuchElementException( "index=" + index + " is free, refClass=" + getRefClass().getSimpleName() );
+		}
 
 		return obj;
 	}
@@ -164,7 +168,7 @@ public abstract class Pool< O extends PoolObject< O, ?, T >, T extends MappedEle
 			public O next()
 			{
 				final int index = pi.next();
-				if ( index >= memPool.allocatedSize )
+				if ( Options.DEBUG && ( index >= memPool.allocatedSize ) )
 					throw new NoSuchElementException();
 
 				obj.updateAccess( Pool.this, index );

--- a/src/main/java/org/mastodon/util/DebugHelpers.java
+++ b/src/main/java/org/mastodon/util/DebugHelpers.java
@@ -1,0 +1,45 @@
+package org.mastodon.util;
+
+import java.io.PrintStream;
+
+public class DebugHelpers
+{
+	public static void printStackTrace( String ... unlessContains )
+	{
+		printStackTrace( System.out, 3, -1, unlessContains );
+	}
+
+	public static void printStackTrace( int maxDepth, String ... unlessContains )
+	{
+		printStackTrace( System.out, 3, maxDepth, unlessContains );
+	}
+
+	public static void printStackTrace( PrintStream out, int maxDepth, String ... unlessContains )
+	{
+		printStackTrace( out, 3, maxDepth, unlessContains );
+	}
+
+	public static void printStackTrace( PrintStream out, int startDepth, int maxDepth, String ... unlessContains )
+	{
+		final StackTraceElement[] trace = Thread.currentThread().getStackTrace();
+
+		for ( StackTraceElement element : trace )
+		{
+			final String traceLine = element.toString();
+			for ( String template : unlessContains )
+				if ( traceLine.contains( template ) )
+					return;
+		}
+
+		final int len = ( maxDepth < 0 )
+				? trace.length
+				: Math.min( startDepth + maxDepth, trace.length );
+		for ( int i = startDepth; i < len; ++i )
+		{
+			final String prefix = ( i == startDepth ) ? "" : "    at ";
+			out.println( prefix + trace[ i ].toString() );
+		}
+
+		out.println();
+	}
+}

--- a/src/test/java/org/mastodon/pool/PoolInvalidAccessTest.java
+++ b/src/test/java/org/mastodon/pool/PoolInvalidAccessTest.java
@@ -1,0 +1,125 @@
+package org.mastodon.pool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.junit.Test;
+
+/**
+ * These tests ensure that proper exceptions are raised when a Pool is queries
+ * with invalid index.
+ *
+ */
+public class PoolInvalidAccessTest
+{
+
+	@Test( expected = NoSuchElementException.class )
+	public void testGetObjectNegative()
+	{
+		final int nTargets = 10;
+		final TestObjectPool pool = new TestObjectPool( nTargets );
+
+		final TestObject ref = pool.createEmptyRef();
+		for ( int i = 0; i < nTargets; i++ )
+			pool.create( ref ).init( i );
+
+		// Good.
+		pool.getObject( 0, ref );
+		// Not good.
+		pool.getObject( -1, ref );
+	}
+
+	@Test( expected = NoSuchElementException.class )
+	public void testGetObjectOver()
+	{
+		final int nTargets = 10;
+		final TestObjectPool pool = new TestObjectPool( nTargets );
+
+		final TestObject ref = pool.createEmptyRef();
+		for ( int i = 0; i < nTargets; i++ )
+			pool.create( ref ).init( i );
+
+		pool.getObject( 0, ref );
+		pool.getObject( nTargets + 1, ref );
+	}
+
+	@Test( expected = NoSuchElementException.class )
+	public void testGetObjectDeleted()
+	{
+		final int nTargets = 10;
+		final TestObjectPool pool = new TestObjectPool( nTargets );
+
+		final TestObject ref = pool.createEmptyRef();
+		for ( int i = 0; i < nTargets; i++ )
+			pool.create( ref ).init( i );
+
+		// Remove first 5.
+		final Iterator< TestObject > it = pool.iterator( ref );
+		int nit = 0;
+		while ( it.hasNext() && nit++ < 5 )
+			pool.delete( it.next() );
+
+		// Should crash.
+		pool.getObject( 0, ref );
+	}
+
+	@Test( expected = NoSuchElementException.class )
+	public void testGetObjectInvalid()
+	{
+		final int nTargets = 10;
+		final TestObjectPool pool = new TestObjectPool( nTargets );
+
+		final TestObject ref = pool.createEmptyRef();
+		for ( int i = 0; i < nTargets / 2; i++ )
+			pool.create( ref ).init( i );
+
+		final TestObject o = pool.create( ref ).init( 1234987239 );
+		final int id = o.getInternalPoolIndex();
+
+		for ( int i = 0; i < nTargets / 2; i++ )
+			pool.create( ref ).init( i + 10 );
+
+
+		final TestObject td = pool.getObject( id, ref );
+		pool.delete( td );
+		pool.getObject( id, ref );
+	}
+
+	@Test( expected = NoSuchElementException.class )
+	public void testPoolIterator()
+	{
+		final int nTargets = 10;
+		final TestObjectPool pool = new TestObjectPool( nTargets );
+
+		final TestObject ref = pool.createEmptyRef();
+		for ( int i = 0; i < nTargets; i++ )
+			pool.create( ref ).init( i );
+
+		assertEquals( "Pool does not have the expected size.", nTargets, pool.size() );
+
+		// Remove them all.
+		for ( final TestObject o : pool )
+			pool.delete( o );
+
+		assertEquals( "Pool should be of size 0.", 0, pool.size() );
+
+		final Iterator< TestObject > it = pool.iterator();
+		assertFalse( "Pool iterator should not have a next element.", it.hasNext() );
+
+		// Re-add 5.
+		for ( int i = 0; i < nTargets / 2; i++ )
+			pool.create( ref ).init( nTargets + i );
+
+		// Re-delete
+		for ( final TestObject o : pool )
+			pool.delete( o );
+
+		// Should trigger NoSuchElementException.
+		it.next();
+		pool.releaseRef( ref );
+	}
+
+}

--- a/src/test/java/org/mastodon/pool/PoolInvalidAccessTest.java
+++ b/src/test/java/org/mastodon/pool/PoolInvalidAccessTest.java
@@ -6,15 +6,23 @@ import static org.junit.Assert.assertFalse;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
+import org.mastodon.Options;
 
 /**
- * These tests ensure that proper exceptions are raised when a Pool is queries
+ * These tests ensure that proper exceptions are raised when a Pool is queried
  * with invalid index.
- *
  */
 public class PoolInvalidAccessTest
 {
+	@Before
+	public void checkDebugFlag()
+	{
+		// This class tests DEBUG behaviour. If DEBUG==false, ignore tests.
+		Assume.assumeTrue( Options.DEBUG );
+	}
 
 	@Test( expected = NoSuchElementException.class )
 	public void testGetObjectNegative()


### PR DESCRIPTION
Turn DEBUG checks on/off with a compile-time constant (default: off)

Checks:
 - Check whether ByteUtils methods access out of bounds array values, and
   throw ArrayIndexOutOfBoundsException.
 - Check whether Pool.getObject() tries to retrieve a freed element, and
   throw NoSuchElementException.