### PR TITLE
Improve the performance Pool.createRef() and Pool.releaseRef()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,16 @@
 			<artifactId>imglib2-ij</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<mailingLists>

--- a/src/main/java/org/mastodon/pool/ThreadLocalSoftReferencePool.java
+++ b/src/main/java/org/mastodon/pool/ThreadLocalSoftReferencePool.java
@@ -1,0 +1,51 @@
+package org.mastodon.pool;
+
+import java.lang.ref.SoftReference;
+import java.util.ArrayDeque;
+
+/**
+ * A simple, fast and thread-safe pool, that allows garbage collection of the
+ * pooled objects. The pool is meant to be used in {@link Pool} to store unused
+ * references.
+ * <p>
+ * The idea behind this pool is to use {@link ThreadLocal} to have one pool per
+ * thread. These thread local pools don't need to be thread-safe. They can
+ * therefore by much simple and faster.
+ * <p>
+ * Additionally {@link SoftReference}s are used to allow garbage collection.
+ */
+class ThreadLocalSoftReferencePool<T>
+{
+	private final ThreadLocal<SoftReference<ArrayDeque<T>>> queues = ThreadLocal.withInitial(
+			() -> new SoftReference<>( new ArrayDeque<>() )
+	);
+
+	/**
+	 * Gets an object from the pool.
+	 *
+	 * @return the object or null, if the pool is empty.
+	 */
+	public T get()
+	{
+		ArrayDeque<T> queue = queues.get().get();
+		if(queue == null)
+			return null;
+		return queue.pollLast();
+	}
+
+	/**
+	 * Puts an object into the pool.
+	 *
+	 * @param element
+	 */
+	public void put( T element )
+	{
+		ArrayDeque<T> queue = queues.get().get();
+		if(queue == null)
+		{
+			queue = new ArrayDeque<>();
+			queues.set(new SoftReference<>( queue ));
+		}
+		queue.push( element );
+	}
+}

--- a/src/test/java/org/mastodon/pool/ConcurrentPoolBenchmark.java
+++ b/src/test/java/org/mastodon/pool/ConcurrentPoolBenchmark.java
@@ -1,0 +1,162 @@
+/*-
+ * #%L
+ * Mastodon Collections
+ * %%
+ * Copyright (C) 2015 - 2022 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.pool;
+
+import net.imglib2.parallel.TaskExecutors;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * This benchmark compares the performance of {@link ConcurrentLinkedQueue}
+ * against {@link ThreadLocalSoftReferencePool}.
+ */
+
+@BenchmarkMode( Mode.AverageTime )
+@OutputTimeUnit( TimeUnit.MILLISECONDS )
+@Fork( 1 )
+@Warmup( iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS )
+@Measurement( iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS )
+@State( Scope.Benchmark )
+public class ConcurrentPoolBenchmark
+{
+
+	@Param({"false", "true"})
+	public boolean multiThreaded;
+
+	@Benchmark
+	public void benchmarkNoPool()
+	{
+		runBenchmark( () -> null, ignore -> {});
+	}
+
+	@Benchmark
+	public void benchmarkConcurrentLinkedQueue()
+	{
+		Queue<Object> queue = new ConcurrentLinkedQueue<>();
+		runBenchmark( queue::poll, queue::add );
+	}
+
+	@Benchmark
+	public void benchmarkThreadLocalSoftReferencePool()
+	{
+		final ThreadLocalSoftReferencePool<Object> pool = new ThreadLocalSoftReferencePool<>();
+		runBenchmark( pool::get, pool::put );
+	}
+
+	private void runBenchmark( Supplier<Object> get, Consumer<Object> put )
+	{
+		if(multiThreaded)
+			multiThreadedBenchmark( get, put );
+		else
+			runBenchmarkTask( get, put );
+	}
+
+	private void multiThreadedBenchmark( Supplier<Object> get, Consumer<Object> put )
+	{
+		List<Integer> indices = IntStream.range( 0, 8 ).boxed().collect( Collectors.toList() );
+		TaskExecutors.multiThreaded().forEach( indices,
+				ignore -> runBenchmarkTask( get, put )
+		);
+	}
+
+	private void runBenchmarkTask( Supplier<Object> get, Consumer<Object> put )
+	{
+		for ( int i = 0; i < 1000; i++ )
+			runRecursive( get, put, 1000 );
+	}
+
+	private static void runRecursive( Supplier<Object> get, Consumer<Object> put, final int value )
+	{
+		if( value < 0)
+			return;
+
+		// get SimpleObject from pool
+		SimpleObject object = ( SimpleObject ) get.get();
+		if(object == null)
+			object = new SimpleObject();
+
+		// set value
+		object.set( value );
+
+		runRecursive( get, put, value - 1 );
+
+		// get value and make sure it didn't change
+		if(object.get() != value )
+			throw new AssertionError("The pool seems to be broken");
+
+		// return SimpleObject to pool
+		put.accept( object );
+	}
+
+	private static class SimpleObject
+	{
+
+		// NB: Having an array here means that creating this "SimpleObject" will
+		// take a little longer. How large this array is, affects the benchmark
+		// results. When the array is small, than using no poll is the fastest
+		// approach.
+		private final int[] values = new int[20];
+
+		public int get() {
+			return values[0];
+		}
+
+		public void set(int value) {
+			values[0] = value;
+		}
+	}
+
+	public static void main(String... args) throws RunnerException
+	{
+		Options options = new OptionsBuilder().include( ConcurrentPoolBenchmark.class.getName() ).build();
+		new Runner( options ).run();
+	}
+
+}

--- a/src/test/java/org/mastodon/pool/ThreadLocalSoftReferenceMemoryTest.java
+++ b/src/test/java/org/mastodon/pool/ThreadLocalSoftReferenceMemoryTest.java
@@ -1,0 +1,62 @@
+/*-
+ * #%L
+ * Mastodon Collections
+ * %%
+ * Copyright (C) 2015 - 2022 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.mastodon.pool;
+
+import org.junit.Test;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * This test verifies if the garbage collector, can clean the content of the
+ * {@link ThreadLocalSoftReferencePool}, if the pool holds too much memory.
+ */
+public class ThreadLocalSoftReferenceMemoryTest
+{
+	//@Test
+	public void testConcurrentLinkedQueue() {
+		// This test is expected to fail, because the ConcurrentLinkedQueue
+		// does not allow the queued objects to be garbage collected, if needed.
+		// NB: This code puts ~8GB of memory into the queue
+		ConcurrentLinkedQueue<int[]> pool = new ConcurrentLinkedQueue<>();
+		for ( int i = 0; i < 1_000_000; i++ )
+		{
+			pool.add( new int[ 2000 ] );
+		}
+	}
+
+	@Test
+	public void testFastConcurrentPool() {
+		// NB: This code puts ~8GB of memory into the pool
+		ThreadLocalSoftReferencePool<int[]> pool = new ThreadLocalSoftReferencePool<>();
+		for ( int i = 0; i < 1_000_000; i++ )
+		{
+			pool.put( new int[ 2000 ] );
+		}
+	}
+}


### PR DESCRIPTION
The class Pool uses a ConcurrentLinkedQueue to store unused references. When profiling some Mastodon code I noticed that the ConcurrentLinkedQueue reduced performance because it triggered regular garbage collector runs.

Using the ConcurrentLinkedQueue has some disadvantages when used to manage the unused references in Pool:
* It is slow when used by multiple threads.
* It creates a new object for each ConcurrentLinkedQueue.add(...) which puts extra load on the garbage collector.
* Unused references are never garbage collected.

This commit introduces a ThreadLocalSoftReferencePool manage the unused references, it is much faster when used with multiple threads. And it does not put extra load on the garbage collector. It also allows the garbage collector to free the unused references if needed.