### PR TITLE
Implement forEach method for ObjectRefMap

### DIFF
--- a/src/main/java/org/mastodon/collection/ObjectRefMap.java
+++ b/src/main/java/org/mastodon/collection/ObjectRefMap.java
@@ -29,6 +29,7 @@
 package org.mastodon.collection;
 
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  * A {@link Map} whose values are object references. It provides variants of
@@ -145,4 +146,25 @@ public interface ObjectRefMap< K, V > extends Map< K, V >
 	 *         depending on concrete implementation.
 	 */
 	public V get( Object key, V ref );
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	default void forEach( BiConsumer< ? super K, ? super V > action )
+	{
+		V ref = createValueRef();
+		try
+		{
+			for ( K key : keySet() )
+			{
+				V value = get( key, ref );
+				action.accept( key, value );
+			}
+		}
+		finally
+		{
+			releaseValueRef( ref );
+		}
+	}
 }

--- a/src/main/java/org/mastodon/collection/wrap/RefRefMapWrapper.java
+++ b/src/main/java/org/mastodon/collection/wrap/RefRefMapWrapper.java
@@ -30,6 +30,7 @@ package org.mastodon.collection.wrap;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 import org.mastodon.collection.ObjectRefMap;
 import org.mastodon.collection.RefCollection;
@@ -154,6 +155,12 @@ public abstract class RefRefMapWrapper< K, V, M extends Map< K, V > > implements
 	public V get( final Object key, final V ref )
 	{
 		return map.get( key );
+	}
+
+	@Override
+	public void forEach( BiConsumer< ? super K, ? super V > action )
+	{
+		map.forEach( action );
 	}
 
 	/**

--- a/src/test/java/org/mastodon/collection/ref/RefRefHashMapTest.java
+++ b/src/test/java/org/mastodon/collection/ref/RefRefHashMapTest.java
@@ -34,6 +34,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.Test;
@@ -215,5 +217,19 @@ public class RefRefHashMapTest extends RefRefHashMapAbstractTest
 	{
 		final OtherTestObject ref = map.createValueRef();
 		assertNotNull( "Created reference object is null.", ref );
+	}
+
+	@Test
+	public void testForEach()
+	{
+		Map<Integer, Integer> result = new HashMap<>();
+		// Use forEach to copy content from RefRefHashMap to java collections HashMap.
+		map.forEach( (key, value) -> result.put( key.getId(), value.getId() ) );
+		// Make sure the content is the same.
+		assertEquals( 4, result.size() );
+		assertEquals( v0.getId(), (int) result.get( k1.getId() ) );
+		assertEquals( v1.getId(), (int) result.get( k2.getId() ) );
+		assertEquals( v2.getId(), (int) result.get( k3.getId() ) );
+		assertEquals( v3.getId(), (int) result.get( k4.getId() ) );
 	}
 }


### PR DESCRIPTION
The forEach method provides a very simple way to correctly iterate over a ObjectRefMap.