### PR TITLE
Tiny change to fix UndoRedoStack.clear()

### DIFF
--- a/src/main/java/org/mastodon/undo/UndoRedoStack.java
+++ b/src/main/java/org/mastodon/undo/UndoRedoStack.java
@@ -183,6 +183,8 @@ public class UndoRedoStack implements UndoPointMarker
 	public void clear()
 	{
 		stack.clear();
+		end = 0;
+		top = 0;
 	}
 
 	/**


### PR DESCRIPTION
The Mastodon Git Collaboration Plugin benefits a lot from the ability to reload the Mastodon Project from disk. This reload can actually be implemented fairly easily. The "reload from disk" operation triggers (intentionally) triggers a `graphRebuilt`. This graphRebuilt triggers a clearing of the undo redo history. But currently the clearing of the undo redo stack doesn't work properly. Adding a spot after a graphRebuilt event fails and triggers an ArrayIndexOutOfBoundsException:

```
Exception in thread "AWT-EventQueue-0" java.lang.ArrayIndexOutOfBoundsException: Array index out of range: 6
	at gnu.trove.list.array.TByteArrayList.set(TByteArrayList.java:298)
	at org.mastodon.undo.UndoRedoStack$ByteAccess.setValue(UndoRedoStack.java:338)
	at org.mastodon.undo.UndoRedoStack.record(UndoRedoStack.java:92)
	at org.mastodon.undo.AbstractUndoableEditType.recordType(AbstractUndoableEditType.java:59)
	at org.mastodon.undo.GraphUndoRedoStack$AddVertexType.record(GraphUndoRedoStack.java:163)
	at org.mastodon.undo.GraphUndoRedoStack$AddVertexType.record(GraphUndoRedoStack.java:144)
	at org.mastodon.undo.GraphUndoRecorder.vertexAdded(GraphUndoRecorder.java:184)
	at org.mastodon.graph.ref.ListenableGraphImp.notifyVertexAdded(ListenableGraphImp.java:149)
	at org.mastodon.graph.ref.ListenableGraphImp$1.notifyVertexAdded(ListenableGraphImp.java:78)
	at org.mastodon.graph.ref.ListenableGraphImp$1.notifyVertexAdded(ListenableGraphImp.java:74)
	at org.mastodon.graph.ref.AbstractListenableVertex.initDone(AbstractListenableVertex.java:147)
	at org.mastodon.mamut.model.Spot.init(Spot.java:144)
	at org.mastodon.mamut.model.ModelOverlayProperties.initVertex(ModelOverlayProperties.java:142)
	at org.mastodon.mamut.model.ModelOverlayProperties.initVertex(ModelOverlayProperties.java:39)
	at org.mastodon.views.bdv.overlay.wrap.OverlayVertexWrapper.init(OverlayVertexWrapper.java:137)
	at org.mastodon.views.bdv.overlay.wrap.OverlayVertexWrapper.init(OverlayVertexWrapper.java:41)
	at org.mastodon.views.bdv.overlay.EditSpecialBehaviours$AddSpotAndLinkIt.init(EditSpecialBehaviours.java:478)
```

This surprising small commit fixes that problem.

(I will open another PR to mastodon core, that thoroughly tests if undo/redo is working properly.)