### PR TITLE
Improve kd tree performance during initialization

### DIFF
--- a/src/main/java/org/mastodon/util/KthElement.java
+++ b/src/main/java/org/mastodon/util/KthElement.java
@@ -1,0 +1,94 @@
+package org.mastodon.util;
+
+import java.util.function.IntToDoubleFunction;
+
+/**
+ * Class for partially sorting a list. The class is used in the KDTree.
+ */
+public class KthElement
+{
+	private KthElement()
+	{
+		// prevent instantiation
+	}
+
+	/**
+	 * Partially sort a sublist such that the element that would be at postition
+	 * {@code k} in a sorted list is at position {@code k}, elements before the k-th
+	 * are smaller or equal and elements after the k-th are larger or equal.
+	 *
+	 * @param i          index of first element of the sublist
+	 * @param j          index of last element of the sublist
+	 * @param k          index for k-th smallest value. i &lt;= k &lt;= j.
+	 * @param rankMethod method that returns i-th rank of the i-th value in the list
+	 * @param swapMethod method that swaps entry i and j in the list
+	 */
+	public static void kthElement( int i, int j, final int k, final IntToDoubleFunction rankMethod, final Swap swapMethod )
+	{
+		while ( i < j )
+		{
+			final int pivotpos = partitionSubList( i, j, rankMethod, swapMethod );
+			if ( k < pivotpos )
+			{
+				// partition lower half
+				j = pivotpos - 1;
+			}
+			else //if ( k >= pivotpos )
+			{
+				// partition upper half
+				i = pivotpos;
+			}
+		}
+	}
+
+	/**
+	 * Partition a sublist.
+	 *
+	 * The method does not swap entries for a correctly sorted list.
+	 *
+	 * @param left     index of first element of the sublist
+	 * @param right    index of last element of the sublist
+	 * @param rankMethod method that returns i-th rank of the i-th value in the list
+	 * @param swapMethod method that swaps entry i and j in the list
+	 * @return the index of the first element of the right partition
+	 */
+	static int partitionSubList( final int left, final int right, final IntToDoubleFunction rankMethod, final Swap swapMethod )
+	{
+		final double pivot = rankMethod.applyAsDouble( ( left + right ) / 2 );
+		int i = left;
+		int j = right;
+
+		while ( true )
+		{
+			double ivalue = rankMethod.applyAsDouble( i );
+			while ( ivalue < pivot )
+			{
+				++i;
+				ivalue = rankMethod.applyAsDouble( i );
+			}
+
+			double jvalue = rankMethod.applyAsDouble( j );
+			while ( pivot < jvalue )
+			{
+				--j;
+				jvalue = rankMethod.applyAsDouble( j );
+			}
+
+			if ( i <= j )
+			{
+				if ( ivalue > jvalue ) // this avoids unnecessary swaps in case of ivalue = jvalue = pivot
+					swapMethod.swap( i, j );
+				++i;
+				--j;
+			}
+
+			if ( i > j )
+				return i;
+		}
+	}
+
+	public interface Swap
+	{
+		void swap( int i, int j );
+	}
+}

--- a/src/test/java/org/mastodon/kdtree/KDTreeInitializationBenchmark.java
+++ b/src/test/java/org/mastodon/kdtree/KDTreeInitializationBenchmark.java
@@ -1,0 +1,40 @@
+package org.mastodon.kdtree;
+
+import net.imglib2.util.StopWatch;
+
+import org.mastodon.collection.RefList;
+import org.mastodon.collection.ref.RefArrayList;
+
+/**
+ * Measure how long it takes to initialize a KDTree with 1_000_000 points
+ * if the points are not randomly distributed, but lie on a circle. This
+ * is a difficult case scenario for KDTree initialization.
+ */
+public class KDTreeInitializationBenchmark
+{
+	public static void main( final String... args )
+	{
+		final int count = 1_000_000;
+
+		final RealPointPool vertexPool = new RealPointPool( 3, count );
+		final RefList< RealPoint > positions = pointsInACircle( vertexPool, count );
+
+		final StopWatch watch = StopWatch.createAndStart();
+		for ( int i = 0; i < 10; i++ )
+			KDTree.kdtree( positions, vertexPool );
+		System.out.println( watch );
+	}
+
+	private static RefList< RealPoint > pointsInACircle( final RealPointPool vertexPool, final int count )
+	{
+		final RefList< RealPoint > positions = new RefArrayList<>( vertexPool );
+		final RealPoint point = positions.createRef();
+		for ( int i = 0; i < count; i++ )
+		{
+			final double angle = 2 * Math.PI * i / count;
+			point.init( Math.sin( angle ), Math.cos( angle ), 1 );
+			positions.add( point );
+		}
+		return positions;
+	}
+}

--- a/src/test/java/org/mastodon/util/KthElementTest.java
+++ b/src/test/java/org/mastodon/util/KthElementTest.java
@@ -1,0 +1,112 @@
+package org.mastodon.util;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.function.IntToDoubleFunction;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link KthElement}.
+ */
+public class KthElementTest
+{
+	@Test
+	public void test()
+	{
+		testKthElement( 1, new int[] { 3, 2, 1 } );
+		testKthElement( 4, new int[] { 4, 3, 2, 1, 5 } );
+		testKthElement( 0, new int[] { 0, 3, 2, 1, 5 } );
+	}
+
+	private static void testKthElement( final int k, final int[] originalList )
+	{
+		final int[] sortedList = originalList.clone();
+		KthElement.kthElement( 0, sortedList.length - 1, k, rankMethod( sortedList ), swapMethod( sortedList ) );
+		assertCorrectPartialSorting( k, originalList, sortedList );
+	}
+
+	private static void assertCorrectPartialSorting( final int k, final int[] original, final int[] partiallySorted )
+	{
+		assertArrayEquals( sortedArray( original ), sortedArray( partiallySorted ) );
+		for ( int i = 0; i < k; i++ )
+			assertTrue( partiallySorted[ i ] <= partiallySorted[ k ] );
+		for ( int i = k + 1; i < partiallySorted.length; i++ )
+			assertTrue( partiallySorted[ i ] >= partiallySorted[ k ] );
+	}
+
+	@Test
+	public void testRandomized()
+	{
+		repeatedlyTestKthElement( 1000, 10, 5 );
+		repeatedlyTestKthElement( 1000, 10, 0 );
+		repeatedlyTestKthElement( 1000, 10, 9 );
+		repeatedlyTestKthElement( 1000, 2, 1 );
+		repeatedlyTestKthElement( 1000, 2, 0 );
+		repeatedlyTestKthElement( 1000, 1, 0 );
+		repeatedlyTestKthElement( 10, 1000, 10 );
+	}
+
+	private static void repeatedlyTestKthElement( final int repeats, final int numberOfValues, final int k )
+	{
+		for ( int seed = 0; seed < repeats; seed++ )
+			testKthElement( k, randomInts( seed, numberOfValues ) );
+	}
+
+	@Test
+	public void testPartitionSubList_forConstantList()
+	{
+		final int[] values = new int[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+		assertEquals( 5, KthElement.partitionSubList( 0, 9, rankMethod( values ), swapMethod( values ) ) );
+	}
+
+	@Test
+	public void testNoSwapForConstantList()
+	{
+		final int[] values = new int[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+		final KthElement.Swap swap = ( i, j ) -> {
+			throw new AssertionError( "Swap should not be called on a constant list." );
+		};
+		KthElement.kthElement( 0, 9, 5, rankMethod( values ), swap );
+	}
+
+	@Test
+	public void testNoSwapForSortedList()
+	{
+		final int[] values = new int[] { 1, 2, 3, 5, 5, 5, 8, 8, 8, 9 };
+		final KthElement.Swap swap = ( i, j ) -> {
+			throw new AssertionError( "Swap should not be called on sorted list." );
+		};
+		KthElement.kthElement( 0, 9, 5, rankMethod( values ), swap );
+	}
+
+	private static int[] sortedArray( final int[] array )
+	{
+		final int[] sorted = array.clone();
+		Arrays.sort( sorted );
+		return sorted;
+	}
+
+	private static int[] randomInts( final int seed, final int count )
+	{
+		return new Random( seed ).ints( count, 0, count ).toArray();
+	}
+
+	private static IntToDoubleFunction rankMethod( final int[] values )
+	{
+		return i -> values[ i ];
+	}
+
+	private static KthElement.Swap swapMethod( final int[] values )
+	{
+		return ( i, j ) -> {
+			final int temp = values[ i ];
+			values[ i ] = values[ j ];
+			values[ j ] = temp;
+		};
+	}
+}


### PR DESCRIPTION
Mastodon opens sometimes very slowly on artificial datasets. Profiling with Java Visual VM showed that  `KDTree` initialization takes very long. More precisely calls to the method `KDTree.kthElement(...)` take up 90% of CPU time.

The method `kthElement` aims to partially sort a list. The implementation is very efficient with a complexity of **O(N)** on randomized list. But strategy for selecting the pivot element is very inefficient when applied to an already sorted list, such that the complexity increases to **O(N²)**. Or when applied to a list that contains several copies of the same constant value. This PR fixing the implementation to work efficient for these special cases.

Unit tests are added to ensure that the new method works as intended.