### PR TITLE
Update parent POM version to 42.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>40.0.0</version>
+		<version>42.0.0</version>
 	</parent>
 
 	<groupId>org.mastodon</groupId>


### PR DESCRIPTION
This pull request updates the parent dependency version in the `pom.xml` file to ensure the project uses the latest build and dependency management features.

* Dependency management:
  * Updated the parent `pom-scijava` version from `40.0.0` to `42.0.0` in `pom.xml` to inherit the latest configuration and dependencies.